### PR TITLE
Use board sizing in tetris_game.h through code

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 #
-# Created by gmakemake (Sparc Sep 12 2019) on Fri Nov 15 11:38:59 2019
+# Created by gmakemake (Sparc Sep 12 2019) on Sat Dec  7 12:29:47 2019
 #
 
 #
@@ -107,11 +107,11 @@ list.o:	list.h
 message.o:	generic.h message.h player.h tetris_game.h
 offline.o:	controller.h generic.h player.h render.h tetris_game.h
 player.o:	generic.h list.h player.h tetris_game.h
-render.o:	render.h
+render.o:	render.h tetris_game.h
 server.o:	generic.h message.h player.h tetris_game.h
 solo_main.o:	tetris_game.h
-test_board.o:	render.h
-test_client_conn.o:	client_conn.h controller.h
+test_board.o:	render.h tetris_game.h
+test_client_conn.o:	client_conn.h controller.h generic.h player.h tetris_game.h
 test_player.o:	generic.h player.h tetris_game.h
 tetris_game.o:	tetris_game.h
 

--- a/src/client.c
+++ b/src/client.c
@@ -10,6 +10,7 @@
 #include "offline.h"
 #include "player.h"
 #include "render.h"
+#include "tetris_game.h"
 
 // local cache of the user's tetris board
 // global variables and static variables are automatically initialized to zero

--- a/src/client_conn.c
+++ b/src/client_conn.c
@@ -14,6 +14,7 @@
 #include "generic.h"
 #include "message.h"
 #include "render.h"
+#include "tetris_game.h"
 
 // for backward compatibility
 #define h_addr h_addr_list[0]
@@ -146,7 +147,7 @@ int read_board(char **cursor, void *board_ptr) {
 	// move the pointer past the name string
 	buffer += name_length + 1;
 	// copy the board
-	memcpy(board, buffer, 960);
+	memcpy(board, buffer, sizeof(int) * BOARD_WIDTH * BOARD_HEIGHT);
 	render_board(board_name, board);
 
 	return EXIT_SUCCESS;
@@ -166,7 +167,6 @@ int read_names(char **cursor) {
 }
 
 int read_from_server(Player *player) {
-	// 1024 bytes is enough for the whole board
 	char buffer[MAXMSG];
 
 	// remember that more than one TCP packet may be read by this command
@@ -215,10 +215,6 @@ int read_from_server(Player *player) {
 }
 
 void *tetris_thread(void *player) {
-	// 1024 bytes is enough for the whole board
-	// char buffer[1280];
-	// ncurses message to display to user
-
 	while (read_from_server((Player *)player) == EXIT_SUCCESS) {
 	}
 

--- a/src/client_conn.h
+++ b/src/client_conn.h
@@ -1,11 +1,9 @@
 #ifndef _CLIENT_CONN_H
 #define _CLIENT_CONN_H
 
-#define BOARD_WIDTH 10
-#define BOARD_HEIGHT 24
-
 #include "controller.h"
 #include "player.h"
+#include "tetris_game.h"
 
 void tetris_send_message(char *message);
 

--- a/src/message.c
+++ b/src/message.c
@@ -6,6 +6,7 @@
 
 #include "message.h"
 #include "player.h"
+#include "tetris_game.h"
 
 /**
  * Write n bytes to socket and return EXIT_SUCCESS or EXIT_FAILURE
@@ -55,7 +56,7 @@ Blob *serialize_state(Player *player) {
 	uint8_t name_length = strlen(player->name);
 	memcpy(blob->bytes + 3, player->name, name_length + 1);
 	// the board is sent directly after the null-byte
-	memcpy(blob->bytes + 4 + name_length, player->view->board, 960);
+	memcpy(blob->bytes + 4 + name_length, player->view->board, sizeof(int) * BOARD_WIDTH * BOARD_HEIGHT);
 	return blob;
 }
 

--- a/src/message.h
+++ b/src/message.h
@@ -2,8 +2,13 @@
 #define MESSAGE_H
 
 #include "player.h"
+#include "tetris_game.h"
 
-#define MAXMSG 1280
+// the message must be able to hold a 4-byte integer for each cell in the
+// board, and must have additional space for metadata (such as the player's
+// name)
+#define MAXMSG (4 * BOARD_WIDTH * BOARD_HEIGHT + 256)
+
 #define MSG_TYPE_REGISTER 'U'
 #define MSG_TYPE_OPPONENT 'O'
 #define MSG_TYPE_ROTATE 'R'

--- a/src/render.c
+++ b/src/render.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "render.h"
+#include "tetris_game.h"
 
 #define CELL_WIDTH 2
 #define BOARD_CH_WIDTH (CELL_WIDTH * BOARD_WIDTH)

--- a/src/render.h
+++ b/src/render.h
@@ -1,10 +1,9 @@
-#include <ncurses.h>
-
 #ifndef _RENDER_HEADER
 #define _RENDER_HEADER
 
-#define BOARD_WIDTH 10
-#define BOARD_HEIGHT 24
+#include <ncurses.h>
+
+#include "tetris_game.h"
 
 void render_init(int n, char *names[]);
 

--- a/src/test_board.c
+++ b/src/test_board.c
@@ -1,6 +1,7 @@
 #include <ncurses.h>
 
 #include "render.h"
+#include "tetris_game.h"
 
 // local cache of the user's tetris board
 // global variables and static variables are automatically initialized to zero


### PR DESCRIPTION
This PR addresses issue #4 

## Changelog

This PR updates all code to respect the board size specified in `tetris_game.h` at build time. The `ncurses` rendering code and the networking message serialization had to be updated.

## Testing

Testing of the server, single-player ncurses client, and multi-player ncurses client were conducted manually. I successfully tested the default board size, as well as a 34x20 board.

## Usage

To change the board size when compiling, you should edit the lines defining `BOARD_WIDTH`, `BOARD_HEIGHT`, `BOARD_PLAY_HEIGHT`, and `BLOCK_START_POSITION` in `tetris_game.h`.

## Future Work

- Allow board size to be specified at runtime
- Document functionality