### PR TITLE
Full stack support for block holding

### DIFF
--- a/src/client_conn.c
+++ b/src/client_conn.c
@@ -92,6 +92,13 @@ static void tetris_drop() {
 	tetris_send_message(message);
 }
 
+static void tetris_swap_hold() {
+	char message[128];
+	sprintf(message, "%c", MSG_TYPE_SWAP_HOLD);
+	tetris_send_message(message);
+	return;
+}
+
 void tetris_list() {
 	char message[128];
 	sprintf(message, "%c", MSG_TYPE_LIST);
@@ -233,6 +240,7 @@ void tetris_listen(Player *player) {
 static const TetrisControlSet TCPControlSet = {.translate = tetris_translate,
                                                .lower = tetris_lower,
                                                .rotate = tetris_rotate,
-                                               .drop = tetris_drop};
+                                               .drop = tetris_drop,
+                                               .swap_hold = tetris_swap_hold};
 
 TetrisControlSet tcp_control_set(void) { return TCPControlSet; }

--- a/src/controller.c
+++ b/src/controller.c
@@ -23,6 +23,9 @@ void keyboard_input_loop(TetrisControlSet controls) {
 		case 'e':
 			controls.rotate(1);
 			break;
+		case 'c':
+			controls.swap_hold();
+			break;
 		}
 	}
 }

--- a/src/controller.h
+++ b/src/controller.h
@@ -10,6 +10,7 @@ typedef struct st_tetris_control_set {
 	void (*lower)(int);
 	void (*rotate)(int);
 	void (*drop)(void);
+	void (*swap_hold)(void);
 } TetrisControlSet;
 
 /**

--- a/src/message.h
+++ b/src/message.h
@@ -15,6 +15,7 @@
 #define MSG_TYPE_TRANSLATE 'T'
 #define MSG_TYPE_LOWER 'L'
 #define MSG_TYPE_DROP 'D'
+#define MSG_TYPE_SWAP_HOLD 'S'
 #define MSG_TYPE_LIST 'P'
 #define MSG_TYPE_BOARD 'B'
 #define MSG_TYPE_LIST_RESPONSE 'Y'

--- a/src/offline.c
+++ b/src/offline.c
@@ -41,12 +41,18 @@ static void offline_drop() {
 	renderish(0, offline_player);
 }
 
+static void offline_swap_hold() {
+	swap_hold_block(offline_player->contents);
+	renderish(0, offline_player);
+}
+
 // define a control set for use offline
-static const TetrisControlSet OfflineControlSet = {.translate =
-                                                       offline_translate,
-                                                   .lower = offline_lower,
-                                                   .rotate = offline_rotate,
-                                                   .drop = offline_drop};
+static const TetrisControlSet OfflineControlSet = {
+    .translate = offline_translate,
+    .lower = offline_lower,
+    .rotate = offline_rotate,
+    .drop = offline_drop,
+    .swap_hold = offline_swap_hold};
 
 /**
  * creates an offline control set for the given player and set the render

--- a/src/render.c
+++ b/src/render.c
@@ -98,9 +98,18 @@ void render_close(void) {
 	endwin();
 }
 
-static void render_cell(WINDOW *win, int row, int col, int color) {
-	mvwaddch(win, 1 + row, 1 + col * CELL_WIDTH, ' ');
-	mvwaddch(win, 1 + row, 2 + col * CELL_WIDTH, ' ');
+/**
+ * Render the terminal background for a coordinate pair in cell-space
+ *
+ * @param win   ncurses window
+ * @param row   index of row
+ * @param col   index of column
+ * @param color color-pair index as passed to ncurses init_pair and used with
+ *              the COLOR_PAIR macro
+ */
+static void render_cell(WINDOW *win, int row, int col, short color) {
+	for (int i=1;i<=CELL_WIDTH; i++)
+		mvwaddch(win, 1 + row, i + col * CELL_WIDTH, ' ');
 	mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, color,
 	         NULL);
 }

--- a/src/render.c
+++ b/src/render.c
@@ -108,7 +108,7 @@ void render_close(void) {
  *              the COLOR_PAIR macro
  */
 static void render_cell(WINDOW *win, int row, int col, short color) {
-	for (int i=1;i<=CELL_WIDTH; i++)
+	for (int i = 1; i <= CELL_WIDTH; i++)
 		mvwaddch(win, 1 + row, i + col * CELL_WIDTH, ' ');
 	mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, color,
 	         NULL);
@@ -127,8 +127,8 @@ static void render_cell(WINDOW *win, int row, int col, short color) {
  */
 static void fill_window(WINDOW *win, short color) {
 	int height, width;
-	getmaxyx(stdscr,height,width);
-	for (int row=0;row<height;row++)
+	getmaxyx(stdscr, height, width);
+	for (int row = 0; row < height; row++)
 		mvwchgat(win, row, 0, width, 0, color, NULL);
 }
 

--- a/src/render.c
+++ b/src/render.c
@@ -105,6 +105,24 @@ static void render_cell(WINDOW *win, int row, int col, int color) {
 	         NULL);
 }
 
+/**
+ * Set the foreground and background color of an entine window
+ *
+ * NOTE: This is different than the bkgd family of functions in ncurses. This
+ * function overrides any existing colors, even if they do not match the
+ * previous color.
+ *
+ * @param win   ncurses window
+ * @param color color-pair index as passed to ncurses init_pair and used with
+ *              the COLOR_PAIR macro
+ */
+static void fill_window(WINDOW *win, short color) {
+	int height, width;
+	getmaxyx(stdscr,height,width);
+	for (int row=0;row<height;row++)
+		mvwchgat(win, row, 0, width, 0, color, NULL);
+}
+
 static struct position rotate_position(struct position pos, enum rotation rot) {
 	switch (rot) {
 	case right:
@@ -175,7 +193,7 @@ void render_game_view_data(char *name, struct game_view_data *view) {
 	wrefresh(bd->message_window);
 
 	// print the next piece and swap piece in the top window
-	wbkgd(bd->top_window, COLOR_PAIR(0));
+	fill_window(bd->top_window, COLOR_PAIR(0));
 	render_tetris_piece(bd->top_window, view->next_block, right,
 	                    (struct position){1, 1});
 	render_tetris_piece(bd->top_window, view->hold_block, left,

--- a/src/render.c
+++ b/src/render.c
@@ -13,6 +13,7 @@ struct board_display {
 	char *name;
 	WINDOW *tetris_window;
 	WINDOW *message_window;
+	WINDOW *top_window;
 };
 
 static struct board_display *boards;
@@ -55,6 +56,7 @@ void render_init(int n, char *names[]) {
 	start_color();
 
 	// create numbered fg/bg pairs to be used by the COLOR_PAIR macro later
+	init_pair(0, COLOR_WHITE, COLOR_WHITE);
 	init_pair(1, COLOR_CYAN, COLOR_CYAN);
 	init_pair(2, COLOR_RED, COLOR_RED);
 	init_pair(3, COLOR_GREEN, COLOR_GREEN);
@@ -82,6 +84,8 @@ void render_init(int n, char *names[]) {
 		                  starty - 1, window_lowx - 1);
 		boards[i].message_window = create_newwin(
 		    3, panel_width, starty + BOARD_HEIGHT + 2, panel_lowx);
+		boards[i].top_window = create_newwin(
+		    5, BOARD_CH_WIDTH + 2, starty - 7, window_lowx - 1);
 	}
 
 	refresh();
@@ -92,6 +96,51 @@ void render_close(void) {
 	// destroy_win(tetris_window);
 	// end curses mode
 	endwin();
+}
+
+static void render_cell(WINDOW *win, int row, int col, int color) {
+	mvwaddch(win, 1 + row, 1 + col * CELL_WIDTH, ' ');
+	mvwaddch(win, 1 + row, 2 + col * CELL_WIDTH, ' ');
+	mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, color,
+	         NULL);
+}
+
+static struct position rotate_position(struct position pos, enum rotation rot) {
+	switch (rot) {
+	case right:
+		return (struct position){.x = pos.y, .y = -pos.x};
+	case invert:
+		return (struct position){.x = -pos.x, .y = -pos.y};
+	case left:
+		return (struct position){.x = -pos.y, .y = pos.x};
+	case none:
+	default:
+		return pos;
+	}
+}
+
+/**
+ * render a tetris piece in a window
+ *
+ * IMPORTANT NOTE: The position for this function is given in ncurses space,
+ * where the origin is the top left. The origin for the tetris library is bottom
+ * left. As a result, this function flips the Y axis while rendering pieces.
+ *
+ * @param win   ncurses window
+ * @param piece tetris piece
+ * @param rot   tetris piece rotation
+ * @param pos   position in ncurses space relative to the window
+ */
+static void render_tetris_piece(WINDOW *win, enum block_type piece,
+                                enum rotation rot, struct position pos) {
+	if (piece < 0 || piece >= BLOCK_TYPE_COUNT)
+		return;
+	struct position cell_offset;
+	for (int i = 0; i < MAX_BLOCK_UNITS; i++) {
+		cell_offset = rotate_position(block_offsets[piece][i], rot);
+		render_cell(win, pos.y - cell_offset.y, pos.x + cell_offset.x,
+		            piece + 1);
+	}
 }
 
 void render_game_view_data(char *name, struct game_view_data *view) {
@@ -109,20 +158,9 @@ void render_game_view_data(char *name, struct game_view_data *view) {
 	// render the tetris window
 	int r, c;
 	for (r = 0; r < BOARD_HEIGHT; r++)
-		for (c = 0; c < BOARD_WIDTH; c++) {
-			mvwaddch(tetris_window, BOARD_HEIGHT - r,
-			         1 + c * CELL_WIDTH, ' ');
-			mvwaddch(tetris_window, BOARD_HEIGHT - r,
-			         2 + c * CELL_WIDTH, ' ');
-			if (board[r][c])
-				mvwchgat(tetris_window, BOARD_HEIGHT - r,
-				         1 + c * CELL_WIDTH, CELL_WIDTH, 0,
-				         board[r][c], NULL);
-			else
-				mvwchgat(tetris_window, BOARD_HEIGHT - r,
-				         1 + c * CELL_WIDTH, CELL_WIDTH, 0, 0,
-				         NULL);
-		}
+		for (c = 0; c < BOARD_WIDTH; c++)
+			render_cell(tetris_window, BOARD_HEIGHT - r - 1, c,
+			            board[r][c]);
 
 	box(tetris_window, 0, 0);
 	wrefresh(tetris_window);
@@ -135,6 +173,16 @@ void render_game_view_data(char *name, struct game_view_data *view) {
 	mvwprintw(bd->message_window, 1, 1, status);
 	box(bd->message_window, 0, 0);
 	wrefresh(bd->message_window);
+
+	// print the next piece and swap piece in the top window
+	// wclear(bd->top_window);
+	wbkgd(bd->top_window, COLOR_PAIR(0));
+	render_tetris_piece(bd->top_window, view->next_block, right,
+	                    (struct position){1, 1});
+	render_tetris_piece(bd->top_window, view->hold_block, left,
+	                    (struct position){BOARD_WIDTH - 2, 1});
+	box(bd->top_window, 0, 0);
+	wrefresh(bd->top_window);
 }
 
 ///

--- a/src/render.c
+++ b/src/render.c
@@ -175,7 +175,6 @@ void render_game_view_data(char *name, struct game_view_data *view) {
 	wrefresh(bd->message_window);
 
 	// print the next piece and swap piece in the top window
-	// wclear(bd->top_window);
 	wbkgd(bd->top_window, COLOR_PAIR(0));
 	render_tetris_piece(bd->top_window, view->next_block, right,
 	                    (struct position){1, 1});

--- a/src/server.c
+++ b/src/server.c
@@ -112,6 +112,9 @@ int read_from_client(int filedes) {
 		case MSG_TYPE_DROP:
 			hard_drop(player->contents);
 			break;
+		case MSG_TYPE_SWAP_HOLD:
+			swap_hold_block(player->contents);
+			break;
 		case MSG_TYPE_OPPONENT:
 			fprintf(stderr, "Opponent: %s\n", cursor + 1);
 			opponent = player_get_by_name(cursor + 1);


### PR DESCRIPTION
Closes #12

This PR adds full-stack support for the recent Tetris library changes in #14.

## Changelog

- Introduce a new message type that the client sends to the server to swap the current block into the hold
- Display the next and hold blocks in ncurses UI

## Testing

I tested the single-player version and multiplayer manually.

![](https://imgur.com/download/9GqycgU/)