### PR TITLE
Add Clang-Format Check to GitHub Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,6 +8,23 @@ defaults:
     working-directory: ./src
 
 jobs:
+
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Clang-Format-10
+      run: |
+        sudo apt-get update &&
+        sudo apt-get install -y --no-install-recommends clang-format-10
+
+    # Keep this check seperate from the other shell commands so that we can
+    # easily view just the clang-format logs in GitHub's CI log viewer.
+    - name: Check Formatting
+      run: /usr/bin/clang-format-10 --dry-run --style=file --Werror $(find . -name '*.c' -o -name '*.h')
+
   build:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Hackathon approved tetris cli online
 
 ## Building
 
+Also see [docs/DEVELOP.md](docs/DEVELOP.md).
+
 ### Setup
 
 - Make sure you have dependencies installed

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -1,0 +1,25 @@
+# Developing
+
+## Formatting
+
+The code in this repository is automatically formatted with clang-format.
+
+If you want to automatically check your code before each commit, run:
+
+```bash
+mkdir -p .git/hooks
+cp docs/pre-commit .git/hooks
+```
+
+# Appendix
+
+## Clang-Format
+
+- clang-format version 10 added a number of nice features, such as a check
+  accessible via the `--dry-run` flag. This is available on Debian testing and
+  the latest Ubuntu release, but not older releases (though it can be installed
+  with a little finagling). See [commit 6e1f7d6][6e1f7d6].
+- For the future, we may also want to look at some of the nice scripts that
+  LLVM maintains in their clang/tools directory.
+
+[6e1f7d6]: https://github.com/llvm/llvm-project/commit/6a1f7d6c9ff8228328d0e65b8678a9c6dff49837

--- a/docs/pre-commit
+++ b/docs/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Pre-commit hook for automatically checking clang-format to catch issues early
+#
+
+ANSI_BOLD=`tput bold`
+ANSI_RED=`tput setaf 1`
+ANSI_RESET=`tput sgr0`
+
+#
+# For the time being, we should support early versions of clang-format. In
+# version 10, a number of new command line arguments like `--dry-run` were
+# added, but this package isn't easily available on all systems.
+#
+git diff --cached --name-only --diff-filter=ACMRT |
+	grep "\.[ch]$" |
+	xargs -n1 clang-format -style=file -output-replacements-xml |
+	grep "<replacement " >/dev/null
+
+if [ $? -ne 1 ]; then
+	cat <<-EOF
+		${ANSI_RED}Git pre-commit check failed:
+		The commit does not match clang-format${ANSI_RESET}
+
+		To fix this, run ${ANSI_BOLD}clang-format -style=file *.h *.c${ANSI_RESET} from the src directory
+	EOF
+	exit 1
+fi
+

--- a/src/client.c
+++ b/src/client.c
@@ -19,8 +19,7 @@ int board[BOARD_HEIGHT][BOARD_WIDTH];
 /**
  * print the usage and exit
  */
-void usage()
-{
+void usage() {
 	fprintf(
 	    stderr,
 	    "Usage: ./client [-h] [-l] [-s] [-u USERNAME] [-o OPPONENT] [-a "

--- a/src/client.c
+++ b/src/client.c
@@ -19,7 +19,8 @@ int board[BOARD_HEIGHT][BOARD_WIDTH];
 /**
  * print the usage and exit
  */
-void usage() {
+void usage()
+{
 	fprintf(
 	    stderr,
 	    "Usage: ./client [-h] [-l] [-s] [-u USERNAME] [-o OPPONENT] [-a "


### PR DESCRIPTION
This patch makes progress towards #13.

### GitHub Actions

This patch adds a clang-format check to GitHub Actions. Note that clang-format 10+ is required for the use of the `--dry-run` and `-Werror` flags.

I make clang-format a separate job so that it can run in parallel with `build`, but I did keep the definition in the same YAML file.

### Pre-Commit Hook

I also added a pre-commit hook, which you can install via:

```bash
mkdir -p .git/hooks
cp docs/pre-commit .git/hooks
```