### PR TITLE
Use DoozyX/clang-format-lint-action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,16 +14,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install Clang-Format-10
-      run: |
-        sudo apt-get update &&
-        sudo apt-get install -y --no-install-recommends clang-format-10
-
-    # Keep this check seperate from the other shell commands so that we can
-    # easily view just the clang-format logs in GitHub's CI log viewer.
-    - name: Check Formatting
-      run: /usr/bin/clang-format-10 --dry-run --style=file --Werror $(find . -name '*.c' -o -name '*.h')
+    
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: './src'
+        extensions: 'h,c'
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rather than install clang-format directly, this patch updates our GitHub Actions workflow to use a pre-made marketplace image.

## Pros

- This marketplace action installs clang-format on the Docker image ahead of time, which means that the formatting check *should* be faster in CI.

## Cons

- We no longer manage installation of clang-format. It's possible the marketplace action could change and require maintenance in the future.

## Alternatives considered

1. I considered using the first-party [actions/cache](https://github.com/actions/cache) action to cache clang-format and its requirements, but my POC demonstrated that this will be significantly more work, and may rot in the future.
2. I considered that we could build our own Docker image for CI, which would solve the burden of installing clang-format during each run of CI. However, this is truly an unnecessary task at this point when a third-party marketplace image is readily available.