### PR TITLE
Implement the Player Lobby

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,8 @@ add_definitions('-std=gnu99')
 find_package(Threads)
 find_package(Curses)
 
+set(ADDITIONAL_LIBRARIES form menu)
+
 list(APPEND ttetris_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/tetris_game.c
     ${CMAKE_CURRENT_LIST_DIR}/client_conn.c
@@ -20,6 +22,7 @@ list(APPEND ttetris_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/offline.c
     ${CMAKE_CURRENT_LIST_DIR}/player.c
     ${CMAKE_CURRENT_LIST_DIR}/render.c
+    ${CMAKE_CURRENT_LIST_DIR}/widgets.c
 )
 
 add_library(ttetrislib OBJECT ${ttetris_SOURCES})
@@ -31,9 +34,9 @@ add_executable(test_render test_render.c $<TARGET_OBJECTS:ttetrislib>)
 add_executable(test_client_conn test_client_conn.c $<TARGET_OBJECTS:ttetrislib>)
 add_executable(test_player test_player.c $<TARGET_OBJECTS:ttetrislib>)
 
-target_link_libraries(solo_main ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(client ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(server ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(test_render ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(test_client_conn ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(test_player ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(solo_main ${CMAKE_THREAD_LIBS_INIT} ${ADDITIONAL_LIBRARIES})
+target_link_libraries(client ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ADDITIONAL_LIBRARIES})
+target_link_libraries(server ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ADDITIONAL_LIBRARIES})
+target_link_libraries(test_render ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ADDITIONAL_LIBRARIES})
+target_link_libraries(test_client_conn ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ADDITIONAL_LIBRARIES})
+target_link_libraries(test_player ${CURSES_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${ADDITIONAL_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ list(APPEND ttetris_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/widgets.c
 )
 
-add_library(ttetrislib OBJECT ${ttetris_SOURCES})
+add_library(ttetrislib OBJECT ${ttetris_SOURCES} log.h log.c)
 
 add_executable(solo_main solo_main.c tetris_game.c)
 add_executable(client client.c $<TARGET_OBJECTS:ttetrislib>)

--- a/src/client.c
+++ b/src/client.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include "client_conn.h"
+#include "log.h"
 #include "offline.h"
 #include "player.h"
 #include "render.h"
@@ -103,6 +104,9 @@ int main(int argc, char *argv[]) {
 
 	int should_run_offline = 0;
 	int list_players = 0;
+
+	// set the logger file pointer to /dev/null
+	logging_set_fp(fopen("/dev/null", "w"));
 
 	// Parse command line flags. The optstring passed to getopt has a
 	// preceding colon to tell getopt that missing flag values should be

--- a/src/client.c
+++ b/src/client.c
@@ -54,10 +54,8 @@ int run_list_online_players(char *host, int port) {
 
 	StringArray *names = tetris_list(net_client);
 	for (int i = 0; i < names->length; i++) {
-		fprintf(stderr, "%s\n", get_string_array(names, i));
+		fprintf(stderr, "%s\n", string_array_get_item(names, i));
 	}
-
-	// connect to the server
 
 	tetris_disconnect(net_client);
 	return EXIT_SUCCESS;

--- a/src/client_conn.c
+++ b/src/client_conn.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "client_conn.h"
+#include "log.h"
 #include "message.h"
 #include "render.h"
 #include "tetris_game.h"
@@ -28,7 +29,7 @@ static void init_sockaddr(struct sockaddr_in *name, const char *hostname,
 	name->sin_port = htons(port);
 	hostinfo = gethostbyname(hostname);
 	if (hostinfo == NULL) {
-		fprintf(stderr, "Unknown host %s.\n", hostname);
+		fprintf(logging_fp, "Unknown host %s.\n", hostname);
 		exit(EXIT_FAILURE);
 	}
 	name->sin_addr = *(struct in_addr *)hostinfo->h_addr;

--- a/src/client_conn.c
+++ b/src/client_conn.c
@@ -95,7 +95,7 @@ StringArray *tetris_list(NetClient *net_client) {
 	Blob *body = malloc(sizeof(Blob));
 	body->bytes = request->cursor + 1;
 	body->length = header->content_length;
-	return deserialize_string_array(body);
+	return string_array_deserialize(body);
 }
 
 /**

--- a/src/client_conn.h
+++ b/src/client_conn.h
@@ -1,23 +1,79 @@
 #ifndef _CLIENT_CONN_H
 #define _CLIENT_CONN_H
 
+#include <sys/types.h>
+
 #include "controller.h"
+#include "list.h"
 #include "player.h"
 #include "tetris_game.h"
 
-void tetris_send_message(char *message);
+typedef struct ttetris_netclient NetClient;
 
-int tetris_connect(char *host, int port);
+struct ttetris_netclient {
+	/* the current file descriptor */
+	int fd;
+	// mark whether the listening thread is running. There is no "undefined"
+	// value to store for pthread_t, so we need this.
+	char is_listen_thread_started;
+	/* thread for listening to the server */
+	pthread_t listen_thread;
+	/* optional list of online players */
+	List *online_players;
+	/* optional field to use for callbacks */
+	Player *player;
+	List *open_requests;
+};
 
-void tetris_disconnect();
+typedef struct ttetris_netrequest NetRequest;
 
-void tetris_list();
+struct ttetris_netrequest {
+	/* id should uniquely identify a request. ids can be re-used after the
+	request is considered to be completed */
+	short id;
+	/* pointer to response content */
+	char *cursor;
+	/* multithreading condition junk */
+	int ready_flag;
+	pthread_mutex_t ready_mutex;
+	pthread_cond_t ready_cond;
+};
 
-void tetris_listen(Player *player);
+/**
+ * send a message to the server using the given client connection
+ */
+NetRequest *ttetris_net_request(NetClient *client, char *bytes,
+                                u_int16_t nbytes);
 
-void tetris_register(char *username);
+/**
+ * set the response for a given net request
+ *
+ * Note: This is mostly an internal-only function. This should be called by a
+ separate thread that is listening to the
+ * TCP network socket.
+ */
+void ttetris_net_request_complete(NetRequest *request);
 
-void tetris_opponent(char *username);
+/**
+ * block until a response is received for the given request
+ */
+void ttetris_net_request_block_for_response(NetRequest *request);
+
+NetClient *net_client_init();
+
+void tetris_send_message(NetClient *net_client, char *body);
+
+void tetris_connect(NetClient *net_client, char *host, int port);
+
+void tetris_disconnect(NetClient *net_client);
+
+StringArray *tetris_list(NetClient *net_client);
+
+void tetris_listen(NetClient *net_client);
+
+void tetris_register(NetClient *net_client, char *username);
+
+void tetris_opponent(NetClient *net_client, char *username);
 
 TetrisControlSet tcp_control_set(void);
 

--- a/src/controller.c
+++ b/src/controller.c
@@ -1,30 +1,30 @@
 #include "controller.h"
 #include <ncurses.h>
 
-void keyboard_input_loop(TetrisControlSet controls) {
+void keyboard_input_loop(TetrisControlSet controls, void *context) {
 	char ch;
 	while ((ch = getch()) != 27) {
 		switch (ch) {
 		case 'a':
-			controls.translate(0);
+			controls.translate(context, 0);
 			break;
 		case 'w':
-			controls.drop();
+			controls.drop(context);
 			break;
 		case 's':
-			controls.lower(1);
+			controls.lower(context);
 			break;
 		case 'd':
-			controls.translate(1);
+			controls.translate(context, 1);
 			break;
 		case 'q':
-			controls.rotate(0);
+			controls.rotate(context, 0);
 			break;
 		case 'e':
-			controls.rotate(1);
+			controls.rotate(context, 1);
 			break;
 		case 'c':
-			controls.swap_hold();
+			controls.swap_hold(context);
 			break;
 		}
 	}

--- a/src/controller.h
+++ b/src/controller.h
@@ -6,17 +6,21 @@
  * provided by other files.
  */
 typedef struct st_tetris_control_set {
-	void (*translate)(int);
-	void (*lower)(int);
-	void (*rotate)(int);
-	void (*drop)(void);
-	void (*swap_hold)(void);
+	void (*translate)(void *context, int);
+	void (*lower)(void *context);
+	void (*rotate)(void *context, int);
+	void (*drop)(void *context);
+	void (*swap_hold)(void *context);
 } TetrisControlSet;
 
 /**
  * capture input from the keyboard and execute the correct function from the
  * provided control set
+ * @param controls struct containing methods to be called in response to
+ * keypress events
+ * @param context pointer to an object that will be passed to the methods
+ * in the given control set
  */
-void keyboard_input_loop(TetrisControlSet controls);
+void keyboard_input_loop(TetrisControlSet controls, void *context);
 
 #endif

--- a/src/generic.c
+++ b/src/generic.c
@@ -34,7 +34,7 @@ void set_string_array(StringArray *arr, int index, char *value) {
 	memcpy(arr->strings[index], value, len);
 }
 
-char *get_string_array(StringArray *arr, int index, char *value) {
+char *get_string_array(StringArray *arr, int index) {
 	return arr->strings[index];
 }
 

--- a/src/generic.h
+++ b/src/generic.h
@@ -17,7 +17,7 @@ typedef struct st_string_array {
 
 StringArray *create_string_array(int length);
 void set_string_array(StringArray *arr, int index, char *value);
-char *get_string_array(StringArray *arr, int index, char *value);
+char *get_string_array(StringArray *arr, int index);
 void destroy_string_array(StringArray *arr);
 Blob *serialize_string_array(StringArray *arr);
 StringArray *deserialize_string_array(Blob *blob);

--- a/src/generic.h
+++ b/src/generic.h
@@ -10,17 +10,39 @@ Blob *create_blob(int length);
 void resize_blob(Blob *blob, int length);
 void shift_blob(Blob *blob, int shift);
 
+/**
+ * StringArray is used as a higher-level representation of an array of strings.
+ *
+ * Goals:
+ * - easily serializable and deserializable
+ *
+ * Notes:
+ * - StringArray manages the memory for each string it contains. This means
+ *   that when setting an item, the string will be copied to a new memory
+ *   allocation.
+ * - Resizing this type is also more efficient than using a builtin array
+ */
 typedef struct st_string_array {
 	int length;
 	char **strings;
 } StringArray;
 
-StringArray *create_string_array(int length);
-void set_string_array(StringArray *arr, int index, char *value);
-char *get_string_array(StringArray *arr, int index);
-void destroy_string_array(StringArray *arr);
-Blob *serialize_string_array(StringArray *arr);
-StringArray *deserialize_string_array(Blob *blob);
+StringArray *string_array_create(int length);
+void string_array_destroy(StringArray *arr);
+
+/**
+ * If the length is shorter than the previous length, then strings will be
+ * automatically cleaned up and freed.
+ *
+ * @param new_length
+ */
+void string_array_resize(StringArray *arr, int new_length);
+
+void string_array_set_item(StringArray *arr, int index, char *value);
+char *string_array_get_item(StringArray *arr, int index);
+
+Blob *string_array_serialize(StringArray *arr);
+StringArray *string_array_deserialize(Blob *blob);
 
 #endif
 

--- a/src/list.h
+++ b/src/list.h
@@ -1,14 +1,19 @@
+#ifndef TTETRIS_LIST_H
+#define TTETRIS_LIST_H
+
 struct st_node {
 	void *target;
 	struct st_node *next;
 };
+
+typedef struct st_list List;
 
 struct st_list {
 	struct st_node *head;
 	int length;
 };
 
-struct st_list *list_create();
+List *list_create();
 
 struct st_node *list_get(struct st_list *list, int index);
 
@@ -17,3 +22,5 @@ struct st_node *list_search(struct st_list *list, int (*match)(void *));
 void list_append(struct st_list *list, void *target);
 
 void list_free(struct st_list *list);
+
+#endif // TTETRIS_LIST_H

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+#include "log.h"
+
+void logging_set_fp(FILE *fp) { logging_fp = fp; }

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,10 @@
+#ifndef TTETRIS_LOG_H
+#define TTETRIS_LOG_H
+
+#include <stdio.h>
+
+FILE *logging_fp;
+
+void logging_set_fp(FILE *file_pointer);
+
+#endif // TTETRIS_LOG_H

--- a/src/message.c
+++ b/src/message.c
@@ -39,7 +39,7 @@ int message_nbytes(int socket_fd, char *bytes, int nbytes, int request_id) {
  */
 int send_online_users(int filedes, int request_id) {
 	StringArray *arr = player_names();
-	Blob *blob = serialize_string_array(arr);
+	Blob *blob = string_array_serialize(arr);
 	shift_blob(blob, 1);
 	blob->bytes[0] = MSG_TYPE_LIST_RESPONSE;
 	printf("send_online_users: message blob length: %d\n", blob->length);

--- a/src/message.h
+++ b/src/message.h
@@ -4,6 +4,8 @@
 #include "player.h"
 #include "tetris_game.h"
 
+typedef char MessageTypeField[1];
+
 // the message must be able to hold a 4-byte integer for each cell in the
 // board, and must have additional space for metadata (such as the player's
 // name)
@@ -20,9 +22,16 @@
 #define MSG_TYPE_BOARD 'B'
 #define MSG_TYPE_LIST_RESPONSE 'Y'
 
-int message_nbytes(int socket_fd, char *bytes, int n);
+typedef struct ttetris_msg_header MessageHeader;
 
-int send_online_users(Player *player);
+struct ttetris_msg_header {
+	u_int16_t request_id;
+	u_int16_t content_length;
+};
+
+int message_nbytes(int socket_fd, char *bytes, int n, int request_id);
+
+int send_online_users(int filedes, int request_id);
 
 int send_player(int socket_fd, Player *player);
 

--- a/src/offline.c
+++ b/src/offline.c
@@ -21,27 +21,27 @@ static int renderish(int fd, Player *player) {
 	return EXIT_SUCCESS;
 }
 
-static void offline_translate(int x) {
+static void offline_translate(void *context, int x) {
 	translate_block(x, offline_player->contents);
 	renderish(0, offline_player);
 }
 
-static void offline_lower() {
+static void offline_lower(void *context) {
 	lower_block(0, offline_player->contents);
 	renderish(0, offline_player);
 }
 
-static void offline_rotate(int theta) {
+static void offline_rotate(void *context, int theta) {
 	rotate_block(theta, offline_player->contents);
 	renderish(0, offline_player);
 }
 
-static void offline_drop() {
+static void offline_drop(void *context) {
 	hard_drop(offline_player->contents);
 	renderish(0, offline_player);
 }
 
-static void offline_swap_hold() {
+static void offline_swap_hold(void *context) {
 	swap_hold_block(offline_player->contents);
 	renderish(0, offline_player);
 }

--- a/src/player.c
+++ b/src/player.c
@@ -6,6 +6,7 @@
 
 #include "generic.h"
 #include "list.h"
+#include "log.h"
 #include "player.h"
 #include "tetris_game.h"
 
@@ -15,7 +16,7 @@ void player_init() { player_list = list_create(); }
 
 void *player_clock(void *input) {
 	struct st_player *player = (struct st_player *)input;
-	fprintf(stderr, "player_clock: thread started\n");
+	fprintf(logging_fp, "player_clock: thread started\n");
 	while (1) {
 		nanosleep((const struct timespec[]){{0, 500000000L}}, NULL);
 		lower_block(1, player->contents);
@@ -28,7 +29,7 @@ void *player_clock(void *input) {
 		if (player->opponent)
 			player->render(player->opponent->fd, player);
 	}
-	fprintf(stderr, "player_clock: thread exiting\n");
+	fprintf(logging_fp, "player_clock: thread exiting\n");
 	return 0;
 }
 
@@ -68,12 +69,14 @@ Player *player_get_by_name(char *name) {
 	struct st_player *player;
 	for (int i = 0; i < player_list->length; i++) {
 		player = (struct st_player *)(list_get(player_list, i)->target);
-		fprintf(stderr, "player_get_by_name: Checking player '%s'\n",
+		fprintf(logging_fp,
+		        "player_get_by_name: Checking player '%s'\n",
 		        player->name);
 		if (strcmp(player->name, name) == 0)
 			return player;
 	}
-	fprintf(stderr, "player_get_by_name: No player found for '%s'\n", name);
+	fprintf(logging_fp, "player_get_by_name: No player found for '%s'\n",
+	        name);
 	return NULL;
 }
 
@@ -87,9 +90,10 @@ struct st_player *player_create(int fd, char *name) {
 	player->contents = NULL;
 	player->view = malloc(sizeof(struct game_view_data));
 	list_append(player_list, player);
-	fprintf(stderr, "player_create: Created player '%s'\n", player->name);
+	fprintf(logging_fp, "player_create: Created player '%s'\n",
+	        player->name);
 	player_get_by_name(player->name);
-	fprintf(stderr, "player_create: There are now %d players\n",
+	fprintf(logging_fp, "player_create: There are now %d players\n",
 	        player_list->length);
 
 	new_game(&player->contents);
@@ -104,6 +108,7 @@ void player_set_opponent(Player *player, Player *opponent) {
 	player->opponent = opponent;
 	opponent->opponent = player;
 
-	fprintf(stderr, "player_set_opponent: %s and %s are now opponents\n",
+	fprintf(logging_fp,
+	        "player_set_opponent: %s and %s are now opponents\n",
 	        player->name, opponent->name);
 }

--- a/src/player.c
+++ b/src/player.c
@@ -48,12 +48,12 @@ struct st_player *get_player_from_fd(int fd) {
 }
 
 StringArray *player_names() {
-	StringArray *arr = create_string_array(player_list->length);
+	StringArray *arr = string_array_create(player_list->length);
 
 	for (int i = 0; i < player_list->length; i++) {
 		Player *player =
 		    (struct st_player *)(list_get(player_list, i)->target);
-		set_string_array(arr, i, player->name);
+		string_array_set_item(arr, i, player->name);
 	}
 
 	return arr;

--- a/src/render.c
+++ b/src/render.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "log.h"
 #include "render.h"
 #include "tetris_game.h"
 
@@ -176,7 +177,8 @@ void render_game_view_data(char *name, struct game_view_data *view) {
 	struct board_display *bd = board_from_name(name);
 
 	if (bd == 0) {
-		printf("render_game_view_data: no board found for name\n");
+		fprintf(logging_fp,
+		        "render_game_view_data: no board found for name\n");
 		return;
 	}
 

--- a/src/server.c
+++ b/src/server.c
@@ -81,14 +81,12 @@ int read_from_client(int filedes) {
 	char name[16];
 
 	while (cursor < end) {
-		// the first two bytes of the message should be used to indicate
-		// the remaining number of bytes in the message
-		uint16_t message_size = (buffer[0] << 8) + buffer[1];
-		fprintf(stderr, "read_from_client: message size is %d\n",
-		        message_size);
+		MessageHeader *header = (MessageHeader *)buffer;
+		fprintf(stderr, "read_from_client: id=%d n_bytes=%d\n",
+		        header->request_id, header->content_length);
 
 		// increment the cursor to the start of the message body
-		cursor += 2;
+		cursor += sizeof(MessageHeader);
 		fprintf(stderr, "message body: %s\n", cursor);
 
 		switch (cursor[0]) {
@@ -120,7 +118,7 @@ int read_from_client(int filedes) {
 				player_set_opponent(player, opponent);
 			break;
 		case MSG_TYPE_LIST:
-			send_online_users(player);
+			send_online_users(filedes, header->request_id);
 			break;
 		default:
 			fprintf(stderr,
@@ -130,14 +128,15 @@ int read_from_client(int filedes) {
 		}
 
 		// increment the cursor past the message body end
-		cursor += message_size;
+		cursor += header->content_length;
 	}
 
 	// send the game view data to the player
-	send_player(player->fd, player);
+	if (player)
+		send_player(player->fd, player);
 
 	// send the game view data to the player's opponent
-	if (player->opponent)
+	if (player && player->opponent)
 		send_player(player->opponent->fd, player);
 
 	return 0;

--- a/src/server.c
+++ b/src/server.c
@@ -9,6 +9,7 @@
 #include <sys/select.h>
 #include <unistd.h>
 
+#include "log.h"
 #include "message.h"
 #include "player.h"
 
@@ -150,6 +151,9 @@ void usage() {
 int main(int argc, char *argv[]) {
 	char host[128] = "127.0.0.1";
 	char port[6] = "5555";
+
+	// set the logger file pointer to /dev/null
+	logging_set_fp(fopen("/dev/null", "w"));
 
 	// Parse command line flags. The optstring passed to getopt has a
 	// preceding colon to tell getopt that missing flag values should be

--- a/src/test_client_conn.c
+++ b/src/test_client_conn.c
@@ -6,11 +6,12 @@
 #define MESSAGE "Basic functionality test"
 
 int main(void) {
-	tetris_connect(HOST, PORT);
+	NetClient *net_client = net_client_init();
+	tetris_connect(net_client, HOST, PORT);
 
 	/* Send data to the server. */
-	tetris_send_message(MESSAGE);
-	tetris_disconnect();
+	tetris_send_message(net_client, MESSAGE);
+	tetris_disconnect(net_client);
 
 	return 0;
 }

--- a/src/widgets.c
+++ b/src/widgets.c
@@ -1,0 +1,189 @@
+#include <form.h>
+#include <menu.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define CTRLD 4
+
+void print_in_middle(WINDOW *win, int starty, int startx, int width,
+                     char *string, chtype color);
+
+// Not really a proper strip function. This terminates a string as soon as it
+// sees a space.
+static void strip(char *text) {
+	char *c = text;
+	while (*c != ' ' && *c != 0)
+		c += 1;
+	*c = 0;
+}
+
+void ttviz_entry(char *username, char *label) {
+	int label_len = strlen(label);
+
+	FIELD *field[2];
+	FORM *my_form;
+	int ch;
+
+	/* Initialize the fields */
+	field[0] = new_field(1, 10, 4, label_len + 11, 0, 0);
+	field[1] = NULL;
+
+	/* Set field options */
+	set_field_back(field[0],
+	               A_UNDERLINE); /* Print a line for the option 	*/
+	field_opts_off(field[0],
+	               O_AUTOSKIP); /* Don't go to next field when this */
+	                            /* Field is filled up 		*/
+
+	/* Create the form and post it */
+	my_form = new_form(field);
+	post_form(my_form);
+	refresh();
+
+	mvprintw(4, 10, label);
+	refresh();
+
+	/* Loop through to get user requests */
+	while ((ch = getch()) != '\n') {
+		switch (ch) {
+		case KEY_DOWN:
+			/* Go to next field */
+			form_driver(my_form, REQ_NEXT_FIELD);
+			/* Go to the end of the present buffer */
+			/* Leaves nicely at the last character */
+			form_driver(my_form, REQ_END_LINE);
+			break;
+		case KEY_UP:
+			/* Go to previous field */
+			form_driver(my_form, REQ_PREV_FIELD);
+			form_driver(my_form, REQ_END_LINE);
+			break;
+		default:
+			/* If this is a normal character, it gets */
+			/* Printed				  */
+			form_driver(my_form, ch);
+			break;
+		}
+	}
+
+	// call to form driver is necessary before we can read from the field
+	// buffer
+	form_driver(my_form, REQ_VALIDATION);
+	char *result = field_buffer(field[0], 0);
+	strcpy(username, result);
+	// it seems like the form field always has extra spaces, so get rid of
+	// those
+	strip(username);
+
+	/* Un post form and free the memory */
+	unpost_form(my_form);
+	free_form(my_form);
+	free_field(field[0]);
+	free_field(field[1]);
+
+	endwin();
+}
+
+/**
+ * Select from a given number of options
+ */
+int ttviz_select(char **options, int num_options, char *desc) {
+	int win_width = 20;
+	ITEM **my_items;
+	int c, i;
+	MENU *my_menu;
+
+	WINDOW *my_menu_win;
+	my_items = (ITEM **)calloc(num_options, sizeof(ITEM *));
+	for (i = 0; i < num_options; ++i)
+		my_items[i] = new_item(/*name*/ options[i], /*desc*/ NULL);
+
+	/* Crate menu */
+	my_menu = new_menu((ITEM **)my_items);
+
+	/* Create the window to be associated with the menu */
+	my_menu_win = newwin(10, win_width, 4, 4);
+	keypad(my_menu_win, TRUE);
+
+	/* Set main window and sub window */
+	set_menu_win(my_menu, my_menu_win);
+	WINDOW *child_win = derwin(my_menu_win, 6, win_width - 2, 3, 1);
+	set_menu_sub(my_menu, child_win);
+
+	/* Set menu mark to the string " * " */
+	set_menu_mark(my_menu, " * ");
+
+	/* Print a border around the main window and print a title */
+	box(my_menu_win, 0, 0);
+	print_in_middle(my_menu_win, 1, 0, win_width, desc, COLOR_PAIR(1));
+	mvwaddch(my_menu_win, 2, 0, ACS_LTEE);
+	mvwhline(my_menu_win, 2, 1, ACS_HLINE, win_width - 2);
+	mvwaddch(my_menu_win, 2, win_width - 1, ACS_RTEE);
+	refresh();
+
+	/* Post the menu */
+	post_menu(my_menu);
+	wrefresh(my_menu_win);
+
+	while ((c = wgetch(my_menu_win)) != '\n') {
+
+		switch (c) {
+		case KEY_DOWN:
+			menu_driver(my_menu, REQ_DOWN_ITEM);
+			break;
+		case KEY_UP:
+			menu_driver(my_menu, REQ_UP_ITEM);
+			break;
+		}
+		wrefresh(my_menu_win);
+	}
+
+	ITEM *cur = current_item(my_menu);
+	int result = item_index(cur);
+
+	/* Unpost and free all the memory taken up */
+	unpost_menu(my_menu);
+	free_menu(my_menu);
+	for (i = 0; i < num_options; ++i)
+		free_item(my_items[i]);
+
+	// clear the window border
+	wborder(my_menu_win, ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ');
+
+	// run window erase and refresh so that the window will be blank
+	werase(my_menu_win);
+	wrefresh(my_menu_win);
+
+	// delete the window
+	delwin(my_menu_win);
+
+	free(my_items);
+
+	return result;
+}
+
+void print_in_middle(WINDOW *win, int starty, int startx, int width,
+                     char *string, chtype color) {
+	int length, x, y;
+	float temp;
+
+	if (win == NULL)
+		win = stdscr;
+	getyx(win, y, x);
+	if (startx != 0)
+		x = startx;
+	if (starty != 0)
+		y = starty;
+	if (width == 0)
+		width = 80;
+
+	length = strlen(string);
+	temp = (width - length) / 2;
+	x = startx + (int)temp;
+	wattron(win, color);
+	mvwprintw(win, y, x, "%s", string);
+	wattroff(win, color);
+	refresh();
+}

--- a/src/widgets.h
+++ b/src/widgets.h
@@ -1,0 +1,3 @@
+
+void ttviz_entry(char *username, char *label);
+int ttviz_select(char **options, int num_options, char *desc);


### PR DESCRIPTION
Resolves #19

![2020-12-14T12:50_tetris_multiplayer_recording](https://user-images.githubusercontent.com/5495776/102120373-721f8800-3e10-11eb-87eb-1460f1a18bc6.gif)

## Summary

This patch grew a lot, but it works! Rather than specify your username and opponent name via command line arguments for multi-player, this diff allows users to enter their name and then presents them with a list of other online players to select from.

## Changelog

- Separate networking code from player struct
- Standardize message header with a struct for both client and server messages
- :star2: Add a request id field to the new message header, and implement client-side blocking while waiting for a response to the given message id.
  - Note: This is my favorite included change. I think it will allow us to do cool stuff in the future!
- Rename all the StringArray functions to use the "string_array" prefix for consistency and adds a new method to resize string arrays
- Rather than set the game mode to single player via command line arguments, this patch shows a TUI menu to users after running the client that will allow them to select single-player or multi-player. For multi-player, they are able to select an opponent from the list of online players.
- Hide logging for clients, but still show on server

