### PR TITLE
Create compact, resizable renderer

### DIFF
--- a/src/render.h
+++ b/src/render.h
@@ -11,10 +11,12 @@ void render_close(void);
 
 void render_game_view_data(char *board_name, struct game_view_data *view);
 
-void render_message(char *text);
+int print_centered(WINDOW *w, int y, char *text);
 
 WINDOW *create_newwin(int height, int width, int starty, int startx);
 
 void destroy_win(WINDOW *local_win);
+
+void render_refresh_layout(void);
 
 #endif

--- a/src/test_render.c
+++ b/src/test_render.c
@@ -34,7 +34,7 @@ int main(void) {
 	render_init(2, names);
 	render_game_view_data(names[0], &view);
 	render_game_view_data(names[1], &view);
-	render_message("Welcome to Tetris! Press q to quit.");
+	print_centered(stdscr, 1, "Welcome to Tetris! Press q to quit.");
 
 	// wait for 'q' key
 	while (getch() != 'q') {


### PR DESCRIPTION
Resolves #18

![2020-12-19T12:39_tetris_compact_ncurses](https://user-images.githubusercontent.com/5495776/102695790-8b04b080-41f7-11eb-9657-bdaf57f81088.gif)

## Changelog

- Refactor the ncurses tetris renderer to be more vertically compact
- Handle window resize. Previously, the layout was fixed when the game started.
- Display error message to user when the terminal is too small