### PR TITLE
Improve Shadow Block, tet-lib Bugfixes

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -305,13 +305,32 @@ void render_close(void) { render_ingame_cleanup(); }
  *              the COLOR_PAIR macro
  */
 static void render_cell(WINDOW *win, int row, int col, short color) {
-	for (int i = 1; i <= CELL_WIDTH; i++)
-		mvwaddch(win, 1 + row, i + col * CELL_WIDTH, ' ');
-	// Handle Shadow Block
-	if (color == shadow)
-		color = 8;
-	mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, color,
-	         NULL);
+	int i;
+	// Reset Cell
+	mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, -1, NULL);
+	// render shadow block
+	if (color == shadow) {
+		// handle narrow boards
+		if (CELL_WIDTH == 1) {
+			mvwaddch(win, 1 + row, 1 + col * CELL_WIDTH, '#');
+		}
+		// handle wide boards
+		else {
+			mvwaddch(win, 1 + row, 1 + col * CELL_WIDTH, '[');
+			for (i = 2; i < CELL_WIDTH; i++) {
+				mvwaddch(win, 1 + row, i + col * CELL_WIDTH,
+				         ' ');
+			}
+			mvwaddch(win, 1 + row, i + col * CELL_WIDTH, ']');
+		}
+	}
+	// render normal block
+	else {
+		for (i = 1; i <= CELL_WIDTH; i++)
+			mvwaddch(win, 1 + row, i + col * CELL_WIDTH, ' ');
+		mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0,
+		         color, NULL);
+	}
 }
 
 /**

--- a/src/render.c
+++ b/src/render.c
@@ -306,10 +306,11 @@ void render_close(void) { render_ingame_cleanup(); }
  */
 static void render_cell(WINDOW *win, int row, int col, short color) {
 	int i;
-	// Reset Cell
-	mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, -1, NULL);
 	// render shadow block
 	if (color == shadow) {
+		// reset cell
+		mvwchgat(win, 1 + row, 1 + col * CELL_WIDTH, CELL_WIDTH, 0, -1,
+		         NULL);
 		// handle narrow boards
 		if (CELL_WIDTH == 1) {
 			mvwaddch(win, 1 + row, 1 + col * CELL_WIDTH, '#');

--- a/src/tetris_game.c
+++ b/src/tetris_game.c
@@ -297,6 +297,7 @@ static int place_block(struct game_contents *gc) {
 		return 2;
 	generate_new_block(gc);
 	gc->swap_h_block_count = 0;
+	gc->auto_lower_count = 0;
 	return 0;
 }
 
@@ -408,12 +409,14 @@ int generate_game_view_data(struct game_view_data **gvd,
 	generate_shadow_block(gc);
 	get_block_positions(gc->active_block);
 	get_block_positions(gc->shadow_block);
+	// draw shadow_block to board
 	for (i = 0; i < MAX_BLOCK_UNITS; i++) {
-		// draw shadow_block to board
 		cur_unit_pos = gc->shadow_block->board_units[i];
 		(*gvd)->board[cur_unit_pos.y][cur_unit_pos.x] =
 		    ((int)(enum block_type)shadow);
-		// draw active_block to board
+	}
+	// draw active_block to board (separate to ensure overwrite of shadow)
+	for (i = 0; i < MAX_BLOCK_UNITS; i++) {
 		cur_unit_pos = gc->active_block->board_units[i];
 		(*gvd)->board[cur_unit_pos.y][cur_unit_pos.x] =
 		    ((int)gc->active_block->tetris_block.type);


### PR DESCRIPTION
- Improve how the shadow block is rendered
- Fix bug where shadow block was overlain over the active block in gvd
- Fix bug where autodrop counter was not reset

Example with CELL_WIDTH 2
![Peek 2021-02-01 11-44](https://user-images.githubusercontent.com/22133940/106491241-aa445e00-6484-11eb-82d5-7825974e53bf.gif)

Example with CELL_WIDTH 1
![Peek 2021-02-01 11-47](https://user-images.githubusercontent.com/22133940/106491254-aca6b800-6484-11eb-84c7-79b3428e14a4.gif)
